### PR TITLE
Eliminate dependency on ‘paste’ and ‘parallel’

### DIFF
--- a/shell-completion/Makefile
+++ b/shell-completion/Makefile
@@ -1,30 +1,34 @@
-
-.PHONY: command-options clean
+# Setting the number of job runners like this in the makefile only works in
+# GNU Make 4.3 or later. Older versions will require that either an env
+# variable be set before running or command line flag be passed at runtime to
+# get parallel jobs.
+MAKEFLAGS += --jobs=$(shell nproc 2>/dev/null || printf 8)
 
 all: hledger-completion.bash
 
-hledger-completion.bash: hledger-completion.bash.m4 commands-list.txt query-filters.txt generic-options.txt command-options
+COMMANDS := $(sort $(shell hledger | ./output-commands.sh | grep -v ^hledger | sort -u) ui web api)
+CMDOPTFILES := $(foreach CMD,$(COMMANDS),options-$(CMD).txt)
+
+hledger-completion.bash: hledger-completion.bash.m4 commands.txt commands-list.txt query-filters.txt generic-options.txt $(CMDOPTFILES)
 	m4 hledger-completion.bash.m4 > $@
 
 generic-options.txt:
 	hledger -h | ./output-options.sh | sort -u > $@
 
 commands.txt:
-	hledger | ./output-commands.sh | grep -v ^hledger | sort -u > $@
-	echo ui  >> $@
-	echo web >> $@
-	echo api >> $@
+	printf "%s\n" $(COMMANDS) > $@
 
-commands-list.txt: commands.txt
-	paste -sd, $^ | tr -d '\n' > $@
+commands-list.txt:
+	printf "%s,"  $(COMMANDS) | sed 's/,$$//' > $@
 
 #query-filters.txt:
 	# The query filters are hard to extract!
 	# hledger help --cat hledger | sed -n '/^QUERIES/,/^[A-Z]/p'
 
-command-options: commands.txt
-	parallel -j8 'hledger {} -h | ./output-options.sh {} | sort -u > options-{}.txt' < commands.txt
+options-%.txt:
+	hledger $* -h | ./output-options.sh $* | sort -u > $@
 
+.PHONY: clean
 clean:
 	rm -f commands*.txt generic-options.txt options-*.txt
 	rm -f hledger-completion.bash

--- a/shell-completion/README.md
+++ b/shell-completion/README.md
@@ -69,8 +69,10 @@ cd shell-completion/
 make
 ```
 
-Hint: GNU make, GNU m4, and GNU parallel must be installed to call `make`.
-The first two usually are.
+Hint: GNU make and  GNU m4 must be installed to call `make`.
+These are present on most systems anyway.
+Additionally the build will run a lot faster with parallell jobs.
+Use `make -j$(nproc)` for best effect.
 
 The generated completion script must be installed. The package maintainer for
 your distribution should be responsible for this.


### PR DESCRIPTION
This is a quickie based on seeing [this comment](https://github.com/simonmichael/hledger/commit/ce2e0e03d235b32a794490f8a471a96335721957#commitcomment-45162086). This gets the job done but I'm not sure it's better in the end.

* The disadvantage with using GUN `make`’s job control for parallelism in this case is that in order to benefit you have to either have v4.3 (many distros don't have this yet) or remember to add the jobs flag when you run `make`. Most people won't do this and hence will get the slower build.

* The advantage is that it doesn't force people to have GNU `parallel` installed to build (or `paste`, which I also eliminated).

I guess this could go either way depending on what the priorities are.